### PR TITLE
Feat/#1 CI/CD 구축 및 Netflix Eureka Client(Gateway) 설정

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: dev
     permissions:

--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -1,0 +1,28 @@
+name: gateway-service dev CD 파이프라인
+
+on:
+  workflow_run:
+    workflows: ["gateway-service CI pipeline"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+
+    steps:
+      - name: Docker 이미지 dev 서버 배포
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{secrets.DEV_HOST}}
+          username: ${{secrets.DEV_USERNAME}}
+          key: ${{secrets.DEV_KEY}}
+          script: |
+            cd /home/ubuntu
+            docker rm -f gateway-service-dev || true
+            docker compose pull gateway-service-dev
+            docker compose up -d --no-deps --force-recreate --pull always gateway-service-dev
+            docker image prune -f

--- a/.github/workflows/cd-prod.yaml
+++ b/.github/workflows/cd-prod.yaml
@@ -1,0 +1,28 @@
+name: gateway-service prod CD 파이프라인
+
+on:
+  workflow_run:
+    workflows: ["gateway-service CI pipeline"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+
+    steps:
+      - name: Docker 이미지 dev 서버 배포
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{secrets.PROD_HOST}}
+          username: ${{secrets.PROD_USERNAME}}
+          key: ${{secrets.PROD_KEY}}
+          script: |
+            cd /home/ubuntu
+            docker rm -f gateway-service-prod || true
+            docker compose pull gateway-service-prod
+            docker compose up -d --no-deps --force-recreate --pull always gateway-service-prod
+            docker image prune -f

--- a/.github/workflows/cd-prod.yaml
+++ b/.github/workflows/cd-prod.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: prod
     permissions:

--- a/.github/workflows/cd-prod.yaml
+++ b/.github/workflows/cd-prod.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: dev
+    environment: prod
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+name: gateway-service CI pipeline
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: jdk 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Gradle Wrapper 권한 부여
+        run: chmod +x gradlew
+
+      - name: gradle 빌드
+        run: ./gradlew clean build
+
+      - name: 도커 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ secrets.DOCKER_USERNAME }}/unionmate-gateway-service:latest
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:21-jdk
+
+COPY build/libs/*SNAPSHOT.jar app.jar
+
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -Dspring.profiles.active=${PROFILE} -jar /app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,8 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.8'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/unionmate/gateway_service/GatewayServiceApplication.java
+++ b/src/main/java/com/unionmate/gateway_service/GatewayServiceApplication.java
@@ -2,6 +2,10 @@ package com.unionmate.gateway_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootApplication
 public class GatewayServiceApplication {
@@ -10,4 +14,15 @@ public class GatewayServiceApplication {
 		SpringApplication.run(GatewayServiceApplication.class, args);
 	}
 
+	@Bean
+	@LoadBalanced
+	public WebClient.Builder loadBalancedWebClientBuilder() {
+		final WebClient.Builder builder = WebClient.builder();
+		return builder;
+	}
+
+	@Bean
+	public RestClient.Builder restClientBuilder() {
+		return RestClient.builder();
+	}
 }

--- a/src/main/java/com/unionmate/gateway_service/global/SecurityConfig.java
+++ b/src/main/java/com/unionmate/gateway_service/global/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.unionmate.gateway_service.global;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+	@Bean
+	public CorsWebFilter corsWebFilter() {
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowedOrigins(List.of("http://localhost:3000"));
+		config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+		config.setAllowCredentials(true);
+		config.setAllowedHeaders(List.of("*"));
+		config.setExposedHeaders(List.of("Authorization", "Authorization-refresh"));
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+
+		return new CorsWebFilter(source);
+	}
+}

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -21,7 +21,7 @@ public class GatewayConfiguration {
 				)
 				.uri("lb://backend-service"))
 
-			//스웨거를 위한 라우트 설정
+			//스웨거를 위한 라우트 설정(각 서비스마다 등록해줘야 합니다.)
 			.route("backend-service_api_docs", r -> r.path("/api-docs/backend/**")
 				.filters(f -> f
 					.rewritePath("/api-docs/backend/(?<rem>.*)", "/${rem}")

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -19,7 +19,7 @@ public class GatewayConfiguration {
 				.filters(f -> f
 					.removeRequestHeader(HttpHeaders.COOKIE)
 				)
-				.uri("lb://backend"))
+				.uri("lb://backend-service"))
 			.build();
 	}
 }

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -24,7 +24,7 @@ public class GatewayConfiguration {
 			//스웨거를 위한 라우트 설정
 			.route("backend-service_api_docs", r -> r.path("/api-docs/backend/**")
 				.filters(f -> f
-					.rewritePath("/api-docs/bakcend/(?<rem>.*)", "/${rem}")
+					.rewritePath("/api-docs/backend/(?<rem>.*)", "/${rem}")
 				)
 				.uri("lb://backend-service"))
 			.build();

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -1,0 +1,25 @@
+package com.unionmate.gateway_service.global.gateway;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+
+@Configuration
+@Profile({"local","dev"})
+public class GatewayConfiguration {
+
+	@Bean
+	public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
+		return builder.routes()
+			// 인증 필요 없는 라우트
+			.route("backend_route", r -> r.path("/**")
+				.filters(f -> f
+					.removeRequestHeader(HttpHeaders.COOKIE)
+				)
+				.uri("lb://backend"))
+			.build();
+	}
+}

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -20,6 +20,13 @@ public class GatewayConfiguration {
 					.removeRequestHeader(HttpHeaders.COOKIE)
 				)
 				.uri("lb://backend-service"))
+
+			//스웨거를 위한 라우트 설정
+			.route("backend-service_api_docs", r -> r.path("/api-docs/backend/**")
+				.filters(f -> f
+					.rewritePath("/api-docs/bakcend/(?<rem>.*)", "/${rem}")
+				)
+				.uri("lb://backend-service"))
 			.build();
 	}
 }

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -15,7 +15,8 @@ public class GatewayConfiguration {
 	public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
 		return builder.routes()
 			// 인증 필요 없는 라우트
-			.route("backend_route", r -> r.path("/**")
+			// path 경로는 추후 개발에 진행되며 수정될 예정
+			.route("backend_route", r -> r.path("/back")
 				.filters(f -> f
 					.removeRequestHeader(HttpHeaders.COOKIE)
 				)

--- a/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
+++ b/src/main/java/com/unionmate/gateway_service/global/gateway/GatewayConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 
 @Configuration
-@Profile({"local","dev"})
+@Profile({"local","dev","prod"})
 public class GatewayConfiguration {
 
 	@Bean

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8000
+
+spring:
+  main:
+    web-application-type: reactive
+  application:
+    name: gateway-service
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://3.34.87.16:8761/eureka

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,3 +13,12 @@ eureka:
     register-with-eureka: true
     service-url:
       defaultZone: http://3.34.87.16:8761/eureka
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    urls:
+      - name: backend-service
+        url: /api-docs/backend/v3/api-docs

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,3 +13,12 @@ eureka:
     register-with-eureka: true
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    urls:
+      - name: backend-service
+        url: /api-docs/backend/v3/api-docs

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8000
+
+spring:
+  main:
+    web-application-type: reactive
+  application:
+    name: gateway-service
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,4 +12,4 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: http://https://43.200.160.0.nip.io:8761/eureka
+      defaultZone: https://43.200.160.0.nip.io:8761/eureka

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8000
+
+spring:
+  main:
+    web-application-type: reactive
+  application:
+    name: gateway-service
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://https://43.200.160.0.nip.io:8761/eureka

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,4 +12,4 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: https://43.200.160.0.nip.io:8761/eureka
+      defaultZone: http://discovery-service-prod:8761/eureka

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,3 +13,13 @@ eureka:
     register-with-eureka: true
     service-url:
       defaultZone: http://discovery-service-prod:8761/eureka
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    urls:
+      - name: backend-service
+        url: /api-docs/backend/v3/api-docs
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=gateway_service


### PR DESCRIPTION
## Related issue 🛠

- closed #1 

## 작업 내용 💻

- [ ] CI/CD를 구축했습니다.
- [ ] Gateway를 구현하여 모든 요청이 gateway로 들어와 각 서비스로 요청을 보낼 수 있도록 구현했습니다.
- [ ] Gateway-service를 Client로서 Eureka서버에 등록했습니다. 

## 스크린샷 📷

### local 서버
<img width="1882" height="757" alt="image" src="https://github.com/user-attachments/assets/1c6af330-d2de-469b-9899-4d4e6624d237" />

### dev 서버
<img width="1907" height="745" alt="image" src="https://github.com/user-attachments/assets/850c98db-3497-4a1b-bb9c-a0f05a555cf4" />

### prod 서버
<img width="1906" height="1016" alt="image" src="https://github.com/user-attachments/assets/12cf7972-426d-4e22-a871-264a900cd1bb" />
<img width="425" height="165" alt="image" src="https://github.com/user-attachments/assets/516d6424-4b1a-4170-8f40-ca4303441e0e" />

+ 추가적으로 prod 서버의 경우 8761번 포트의 경우 https 적용이 되어있지 않습니다. 왜냐하면 gateway를 포함한 서비스들이 eureka server에 등록이 되지만 모든 요청은 gateway-service에 해당하는 8000번 포트로 받아 각 서비스로 보내지기 때문입니다. 따라서 https 처리는 8000번 포트에 이루어졌습니다.  
다음 사진은 해당 부분을 확인할 수 있는 nginx의 default.conf 코드입니다.

```shell
server {
    listen 80;
    server_name 43.200.160.0.nip.io;

    location /.well-known/acme-challenge/ {
        root /var/www/certbot;
        allow all;
    }

    location /nginx/health {
        access_log off;
        return 200 'ok';
        add_header Content-Type text/plain;
    }

    location / {
        return 301 https://$host$request_uri;
    }
}
server {
    listen 443 ssl;
    http2 on;
    server_name 43.200.160.0.nip.io;

    ssl_certificate     /etc/letsencrypt/live/43.200.160.0.nip.io/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/43.200.160.0.nip.io/privkey.pem;

    # (옵션) mozilla 권장 설정을 쓰고 싶다면 아래 파일들이 있을 때 include
    # include /etc/letsencrypt/options-ssl-nginx.conf;
    # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;

    client_max_body_size 10m;

    location / {
        proxy_pass         http://gateway-service-prod:8000;
        proxy_set_header   Host $host;
        proxy_set_header   X-Real-IP $remote_addr;
        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header   X-Forwarded-Proto $scheme;
    }

    location /nginx/health {
        access_log off;
        return 200 'ok';
        add_header Content-Type text/plain;
    }
}
``` 

### 아키텍처 
최종적으로 구축한 prod 서버의 아키텍처는 다음과 같습니다. 
<img width="1041" height="509" alt="image" src="https://github.com/user-attachments/assets/67635cf5-7df7-4196-826a-43785421f9b9" />
<img width="1274" height="263" alt="image" src="https://github.com/user-attachments/assets/a18057f9-8f4e-44e1-9071-d60dd23d8cb1" />




## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 게이트웨이 서비스 도입: 요청 라우팅 및 /api-docs/backend/**를 통한 백엔드 API 문서 프록시.
  - Swagger UI 제공: /swagger-ui.html에서 API 문서 확인.
  - CORS 활성화: http://localhost:3000 허용, 표준 메서드/헤더 및 인증 정보 지원.
  - WebFlux 기반 전환 및 프로필별 설정(로컬/개발/운영)으로 포트 8000 사용.

- Chores
  - CI 추가: 빌드 및 도커 이미지 빌드/푸시 자동화.
  - Dev/Prod CD 추가: CI 성공 시 원격 서버에 컨테이너 재배포 및 이미지 정리 자동화.
  - Dockerfile 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->